### PR TITLE
Full httpscan

### DIFF
--- a/src/cli/args/scan.rs
+++ b/src/cli/args/scan.rs
@@ -1,5 +1,5 @@
 use crate::lua::threads::runner::{
-    LAST_CUSTOM_SCAN_ID, LAST_HOST_SCAN_ID, LAST_PATH_SCAN_ID, LAST_URL_SCAN_ID, LAST_HTTP_SCAN_ID,
+    LAST_CUSTOM_SCAN_ID, LAST_HOST_SCAN_ID, LAST_HTTP_SCAN_ID, LAST_PATH_SCAN_ID, LAST_URL_SCAN_ID,
 };
 use reqwest::header::HeaderMap;
 use reqwest::header::{HeaderName, HeaderValue};

--- a/src/cli/args/scan.rs
+++ b/src/cli/args/scan.rs
@@ -1,5 +1,5 @@
 use crate::lua::threads::runner::{
-    LAST_CUSTOM_SCAN_ID, LAST_HOST_SCAN_ID, LAST_PATH_SCAN_ID, LAST_URL_SCAN_ID,
+    LAST_CUSTOM_SCAN_ID, LAST_HOST_SCAN_ID, LAST_PATH_SCAN_ID, LAST_URL_SCAN_ID, LAST_HTTP_SCAN_ID,
 };
 use reqwest::header::HeaderMap;
 use reqwest::header::{HeaderName, HeaderValue};
@@ -22,6 +22,10 @@ fn read_resume_file(file_path: &str) -> Result<(), std::io::Error> {
         }
 
         match parts[0] {
+            "HTTP_SCAN_ID" => {
+                let mut scan_id = LAST_HTTP_SCAN_ID.lock().unwrap();
+                *scan_id = parts[1].parse().unwrap_or(0);
+            }
             "URL_SCAN_ID" => {
                 let mut scan_id = LAST_URL_SCAN_ID.lock().unwrap();
                 *scan_id = parts[1].parse().unwrap_or(0);

--- a/src/cli/input.rs
+++ b/src/cli/input.rs
@@ -1,6 +1,6 @@
 use crate::filename_to_string;
 use crate::CliErrors;
-use std::{io, io::BufRead, path::PathBuf};
+use std::{io, io::Read, path::PathBuf};
 use url::Url;
 pub mod load_scripts;
 pub mod parse_requests;
@@ -69,13 +69,11 @@ pub fn get_stdin_input() -> Result<Vec<String>, CliErrors> {
         Err(CliErrors::EmptyStdin)
     } else {
         let stdin = io::stdin();
-        let mut input_lines: Vec<String> = Vec::new();
-        stdin.lock().lines().for_each(|x| {
-            let the_line = x.unwrap();
-            input_lines.push(the_line);
-        });
-        input_lines.sort();
-        input_lines.dedup();
+        let mut input_string = String::new();
+        stdin.lock().read_to_string(&mut input_string).unwrap();
+        let input_lines: Vec<String> = input_string.lines().map(|s| s.to_string()).collect();
+        // input_lines.sort();
+        //input_lines.dedup();
         Ok(input_lines)
     }
 }

--- a/src/cli/input/load_scripts.rs
+++ b/src/cli/input/load_scripts.rs
@@ -66,7 +66,7 @@ pub fn valid_scripts(
     let mut test_target_url: Option<&str> = None;
     let mut test_target_host: Option<&str> = None;
     let mut test_http_msg: Option<FullRequest> = None;
-    log::debug!("Checking Scan Number ID: {}",number_scantype);
+    log::debug!("Checking Scan Number ID: {}", number_scantype);
     match number_scantype {
         0 => test_http_msg = Some(FullRequest::default()),
         1 => {
@@ -117,7 +117,7 @@ pub fn valid_scripts(
             show_msg(log_msg, MessageLevel::Error);
             log::error!("{}", log_msg);
         } else {
-            log::debug!("LOADING STATUS {:?}",code);
+            log::debug!("LOADING STATUS {:?}", code);
             let global = lua_eng.lua.globals();
             let scan_type = global.get::<_, usize>("SCAN_TYPE".to_string());
             if let Err(..) = scan_type {
@@ -134,6 +134,6 @@ pub fn valid_scripts(
             }
         }
     });
-    log::debug!("Loaded scripts: {:?}",used_scripts);
+    log::debug!("Loaded scripts: {:?}", used_scripts);
     used_scripts
 }

--- a/src/cli/input/load_scripts.rs
+++ b/src/cli/input/load_scripts.rs
@@ -1,3 +1,4 @@
+use crate::cli::input::parse_requests::FullRequest;
 use crate::lua::{
     model::LuaRunTime,
     runtime::{encode_ext::EncodeEXT, http_ext::HTTPEXT, utils_ext::UtilsEXT},
@@ -35,17 +36,15 @@ pub fn get_scripts(script_path: PathBuf) -> Vec<(String, String)> {
 /// This Function will return a Tuples in Vector with script path and content
 fn load_scripts(script_path: &PathBuf) -> Result<Vec<(String, String)>, CliErrors> {
     let mut scripts = Vec::new();
-    for entry in glob(script_path.as_os_str().to_str().unwrap())
-        .expect("Failed to read glob pattern")
+    for entry in
+        glob(script_path.as_os_str().to_str().unwrap()).expect("Failed to read glob pattern")
     {
         match entry {
-            Ok(path) => {
-                scripts.push((
+            Ok(path) => scripts.push((
                 filename_to_string(path.to_str().unwrap()).unwrap(),
                 path.to_str().unwrap().to_string(),
-            ))
-            },
-            Err(e) => error!("{}",e.to_string()),
+            )),
+            Err(e) => error!("{}", e.to_string()),
         }
     }
     Ok(scripts)
@@ -66,7 +65,10 @@ pub fn valid_scripts(
 ) -> Vec<(String, String)> {
     let mut test_target_url: Option<&str> = None;
     let mut test_target_host: Option<&str> = None;
+    let mut test_http_msg: Option<FullRequest> = None;
+    log::debug!("Checking Scan Number ID: {}",number_scantype);
     match number_scantype {
+        0 => test_http_msg = Some(FullRequest::default()),
         1 => {
             test_target_host = Some("example.com");
         }
@@ -82,19 +84,21 @@ pub fn valid_scripts(
     lua_eng.add_matchingfunc();
     lua_eng.add_threadsfunc();
     if test_target_host.is_some() {
-        lua_eng.add_httpfuncs(None);
+        lua_eng.add_httpfuncs(None, None);
         lua_eng
             .lua
             .globals()
             .set("INPUT_DATA", "example.com")
             .unwrap();
+    } else if test_http_msg.is_some() {
+        lua_eng.add_httpfuncs(None, test_http_msg)
     } else {
         lua_eng
             .lua
             .globals()
             .set("INPUT_DATA", Vec::<&str>::new())
             .unwrap();
-        lua_eng.add_httpfuncs(test_target_url);
+        lua_eng.add_httpfuncs(test_target_url, None);
     }
     let mut used_scripts: Vec<(String, String)> = Vec::new();
     scripts.iter().for_each(|(script_code, script_path)| {
@@ -113,6 +117,7 @@ pub fn valid_scripts(
             show_msg(log_msg, MessageLevel::Error);
             log::error!("{}", log_msg);
         } else {
+            log::debug!("LOADING STATUS {:?}",code);
             let global = lua_eng.lua.globals();
             let scan_type = global.get::<_, usize>("SCAN_TYPE".to_string());
             if let Err(..) = scan_type {
@@ -124,10 +129,11 @@ pub fn valid_scripts(
                     ),
                     MessageLevel::Error,
                 );
-            } else if scan_type.unwrap() == number_scantype {
+            } else if scan_type.clone().unwrap() == number_scantype {
                 used_scripts.push((script_code.into(), script_path.into()));
             }
         }
     });
+    log::debug!("Loaded scripts: {:?}",used_scripts);
     used_scripts
 }

--- a/src/cli/input/parse_requests.rs
+++ b/src/cli/input/parse_requests.rs
@@ -12,27 +12,6 @@ pub struct FullRequest {
     pub url: String,
     pub headers: HashMap<String, String>,
     pub body: String,
-    #[serde(skip_serializing)]
-    pub injection_place: InjectionPlace
-}
-
-#[derive(Serialize, Deserialize)]
-pub struct InjectionPlace {
-    pub url_scan: bool,
-    pub path_scan: bool,
-    pub headers_scan: bool,
-    pub body_scan: bool,
-}
-
-impl Default for InjectionPlace {
-    fn default() -> Self {
-        Self {
-            url_scan: true,
-            path_scan: false,
-            headers_scan: false,
-            body_scan: false
-        }
-    }
 }
 
 impl Default for FullRequest {
@@ -43,7 +22,6 @@ impl Default for FullRequest {
             url: "http://example.com".to_string(),
             headers,
             body: "".to_string(),
-            injection_place: InjectionPlace::default()
         }
     }
 }
@@ -63,7 +41,7 @@ impl FullRequest {
 
 impl UserData for FullRequest {
     fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
-        methods.add_method("set_param", |_, this, (payload ,remove_param_content) : (String, Option<bool>)| {
+        methods.add_method("set_url_param", |_, this, (payload ,remove_param_content) : (String, Option<bool>)| {
             let remove_content = remove_param_content.unwrap_or(false);
             let test_data = this.inject_payloads(&payload,remove_content);
             Ok(test_data)

--- a/src/cli/input/parse_requests.rs
+++ b/src/cli/input/parse_requests.rs
@@ -63,6 +63,19 @@ impl FullRequest {
         }
         results
     }
+
+    fn inject_body(&self, payload: &str, remove_content: bool) -> HashMap<String, FullRequest> {
+        let mut results = HashMap::new();
+        let req_body = &self.body;
+        results
+    }
+
+    fn is_json(&self, data: &str) -> bool {
+        match serde_json::from_str::<serde_json::Value>(data) {
+            Ok(..) => true,
+            Err(..) => false
+        }
+    }
     fn inject_payloads(
         &mut self,
         payload: &str,

--- a/src/cli/input/parse_requests.rs
+++ b/src/cli/input/parse_requests.rs
@@ -6,12 +6,19 @@ use tealr::TypeName;
 
 use crate::lua::parsing::url::HttpMessage;
 
-#[derive(TypeName,Deserialize, Serialize)]
+#[derive(TypeName, Deserialize, Serialize)]
 pub struct FullRequest {
     pub method: String,
     pub url: String,
     pub headers: HashMap<String, String>,
     pub body: String,
+}
+
+pub enum InjectionLocation {
+    Url,
+    Path,
+    Headers,
+    Body,
 }
 
 impl Default for FullRequest {
@@ -27,24 +34,110 @@ impl Default for FullRequest {
 }
 
 impl FullRequest {
-    fn inject_payloads(&self, payload: &str, remove_content: bool) -> HashMap<String, String> {
+    fn inject_headers(
+        &mut self,
+        payload: &str,
+        remove_content: bool,
+    ) -> HashMap<String, FullRequest> {
+        let headers = &self.headers;
+        let mut results: HashMap<String, FullRequest> = HashMap::new();
+        headers.iter().for_each(|(headername, headervalue)| {
+            let current_headers = &mut self.headers.clone();
+            let mut current_results: HashMap<String, String> = HashMap::new();
+            current_results.insert(headername.into(), {
+                if remove_content {
+                    format!("{}{}", headervalue, payload)
+                } else {
+                    format!("{}", payload)
+                }
+            });
+            current_headers.extend(current_results);
+            results.insert(
+                headername.into(),
+                FullRequest {
+                    method: self.method.clone(),
+                    url: self.url.clone(),
+                    headers: current_headers.clone(),
+                    body: self.body.clone(),
+                },
+            );
+        });
+        results
+    }
+    fn inject_payloads(
+        &mut self,
+        payload: &str,
+        remove_content: bool,
+        injection_location: InjectionLocation,
+    ) -> HashMap<String, FullRequest> {
         let mut injected_params = HashMap::new();
-        let url_parser = HttpMessage {
-            url: Some(Url::parse(&self.url).unwrap())
-        };
-        let iter_params = url_parser.change_urlquery(payload, remove_content);
-        injected_params.extend(iter_params);
-        injected_params
+        match injection_location {
+            InjectionLocation::Url => {
+                let url_parser = HttpMessage {
+                    url: Some(Url::parse(&self.url).unwrap()),
+                };
+                let iter_params = url_parser.change_urlquery(payload, remove_content);
+                let mut results: HashMap<String, FullRequest> = HashMap::new();
+                iter_params.iter().for_each(|(k, v)| {
+                    results.insert(
+                        k.to_string(),
+                        FullRequest {
+                            method: self.method.clone(),
+                            url: v.to_string(),
+                            headers: self.headers.clone(),
+                            body: self.body.clone(),
+                        },
+                    );
+                });
+                injected_params.extend(iter_params);
+                results
+            }
+            InjectionLocation::Headers => self.inject_headers(payload, remove_content),
+            _ => HashMap::new(),
+        }
     }
 }
 
-
 impl UserData for FullRequest {
     fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
-        methods.add_method("set_url_param", |_, this, (payload ,remove_param_content) : (String, Option<bool>)| {
-            let remove_content = remove_param_content.unwrap_or(false);
-            let injected_params = this.inject_payloads(&payload,remove_content);
-            Ok(injected_params)
-        });
+        methods.add_method_mut(
+            "set_url_param",
+            |_, this, (payload, remove_param_content): (String, Option<bool>)| {
+                let remove_content = remove_param_content.unwrap_or(false);
+                let injected_params =
+                    this.inject_payloads(&payload, remove_content, InjectionLocation::Url);
+                Ok(injected_params)
+            },
+        );
+
+        methods.add_method_mut(
+            "set_path_param",
+            |_, this, (payload, remove_param_content): (String, Option<bool>)| {
+                let remove_content = remove_param_content.unwrap_or(false);
+                let injected_params =
+                    this.inject_payloads(&payload, remove_content, InjectionLocation::Path);
+                Ok(injected_params)
+            },
+        );
+
+        methods.add_method_mut(
+            "set_body_param",
+            |_, this, (payload, remove_param_content): (String, Option<bool>)| {
+                let remove_content = remove_param_content.unwrap_or(false);
+                let injected_params =
+                    this.inject_payloads(&payload, remove_content, InjectionLocation::Body);
+                Ok(injected_params)
+            },
+        );
+
+        methods.add_method_mut(
+            "set_headers_param",
+            |_, this, (payload, remove_param_content): (String, Option<bool>)| {
+                let remove_content = remove_param_content.unwrap_or(false);
+                let injected_params =
+                    this.inject_payloads(&payload, remove_content, InjectionLocation::Headers);
+                Ok(injected_params)
+            },
+        );
     }
 }

--- a/src/cli/input/parse_requests.rs
+++ b/src/cli/input/parse_requests.rs
@@ -43,8 +43,8 @@ impl UserData for FullRequest {
     fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
         methods.add_method("set_url_param", |_, this, (payload ,remove_param_content) : (String, Option<bool>)| {
             let remove_content = remove_param_content.unwrap_or(false);
-            let test_data = this.inject_payloads(&payload,remove_content);
-            Ok(test_data)
+            let injected_params = this.inject_payloads(&payload,remove_content);
+            Ok(injected_params)
         });
     }
 }

--- a/src/cli/input/parse_requests.rs
+++ b/src/cli/input/parse_requests.rs
@@ -1,16 +1,72 @@
+use mlua::UserData;
+use reqwest::Url;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use tealr::TypeName;
 
-#[derive(Deserialize, Serialize)]
-pub struct Request {
+use crate::lua::parsing::url::HttpMessage;
+
+#[derive(TypeName,Deserialize, Serialize)]
+pub struct FullRequest {
     pub method: String,
     pub url: String,
     pub headers: HashMap<String, String>,
     pub body: String,
+    #[serde(skip_serializing)]
+    pub injection_place: InjectionPlace
 }
 
 #[derive(Serialize, Deserialize)]
-#[repr(transparent)]
-pub struct ParsedRequests {
-    pub requests: Vec<Request>,
+pub struct InjectionPlace {
+    pub url_scan: bool,
+    pub path_scan: bool,
+    pub headers_scan: bool,
+    pub body_scan: bool,
+}
+
+impl Default for InjectionPlace {
+    fn default() -> Self {
+        Self {
+            url_scan: true,
+            path_scan: false,
+            headers_scan: false,
+            body_scan: false
+        }
+    }
+}
+
+impl Default for FullRequest {
+    fn default() -> Self {
+        let headers = HashMap::new();
+        Self {
+            method: "GET".to_string(),
+            url: "http://example.com".to_string(),
+            headers,
+            body: "".to_string(),
+            injection_place: InjectionPlace::default()
+        }
+    }
+}
+
+impl FullRequest {
+    fn inject_payloads(&self, payload: &str, remove_content: bool) -> HashMap<String, String> {
+        let mut injected_params = HashMap::new();
+        let url_parser = HttpMessage {
+            url: Some(Url::parse(&self.url).unwrap())
+        };
+        let iter_params = url_parser.change_urlquery(payload, remove_content);
+        injected_params.extend(iter_params);
+        injected_params
+    }
+}
+
+
+impl UserData for FullRequest {
+    fn add_methods<'lua, M: mlua::UserDataMethods<'lua, Self>>(methods: &mut M) {
+        methods.add_method("set_param", |_, this, (payload ,remove_param_content) : (String, Option<bool>)| {
+            let remove_content = remove_param_content.unwrap_or(false);
+            let test_data = this.inject_payloads(&payload,remove_content);
+            Ok(test_data)
+        });
+    }
 }

--- a/src/cli/startup/scan/input_handler.rs
+++ b/src/cli/startup/scan/input_handler.rs
@@ -13,7 +13,7 @@ pub fn custom_input_lua(
     };
     lua_env.add_printfunc();
     lua_env.add_matchingfunc();
-    lua_env.add_httpfuncs(None);
+    lua_env.add_httpfuncs(None, None);
     log::debug!("Loading Input handler lua code");
     lua_env.lua.load(code).exec()?;
     let parse_input = lua_env

--- a/src/cli/startup/scan/scan.rs
+++ b/src/cli/startup/scan/scan.rs
@@ -4,10 +4,10 @@ use crate::cli::input::{get_stdin_input, get_target_hosts, get_target_paths};
 use crate::cli::logger::init_log;
 use crate::lua::parsing::files::filename_to_string;
 use crate::{show_msg, Lotus, MessageLevel, RequestOpts};
+use serde_json::Value;
 use std::sync::{Arc, Mutex};
 use structopt::StructOpt;
 use url::Url;
-use serde_json::Value;
 #[path = "input_handler.rs"]
 mod input_handler;
 use input_handler::custom_input_lua;
@@ -110,20 +110,28 @@ pub fn args_scan() -> ScanArgs {
             let mut hosts = vec![];
             let mut parsed_request: Vec<Value> = vec![];
             if input_handler.is_empty() {
-
                 let input_str = input_data.join("\n");
                 let is_json = is_json_string(&input_str);
-                log::debug!("input data is json: {} \n{}",is_json,&input_str);
+                log::debug!("input data is json: {} \n{}", is_json, &input_str);
                 if is_json {
                     let parsed_json: Vec<FullRequest> = match serde_json::from_str(&input_str) {
                         Ok(parsed_request) => parsed_request,
                         Err(err) => {
-                            show_msg(&format!("Not Valid JSON Data for Http Request parser: {}",err.to_string()), MessageLevel::Error);
+                            show_msg(
+                                &format!(
+                                    "Not Valid JSON Data for Http Request parser: {}",
+                                    err.to_string()
+                                ),
+                                MessageLevel::Error,
+                            );
                             std::process::exit(0);
                         }
                     };
                     log::debug!("JSON Data has benn Parsed successfully");
-                    parsed_request = parsed_json.iter().map(|req| serde_json::to_value(req).unwrap()).collect();
+                    parsed_request = parsed_json
+                        .iter()
+                        .map(|req| serde_json::to_value(req).unwrap())
+                        .collect();
                 } else {
                     urls = input_data
                         .iter()
@@ -166,7 +174,7 @@ pub fn args_scan() -> ScanArgs {
 
     log::debug!("HOSTS: {}", hosts.len());
     log::debug!("HTTPMSGS: {}", parse_requests.len());
-    log::debug!("URLS: {}",urls.len());
+    log::debug!("URLS: {}", urls.len());
     log::debug!("PATHS: {}", paths.len());
     log::debug!("CUSTOM: {}", custom.len());
     ScanArgs {
@@ -175,7 +183,7 @@ pub fn args_scan() -> ScanArgs {
             hosts,
             paths,
             custom,
-            parse_requests
+            parse_requests,
         },
         exit_after,
         is_request,
@@ -188,11 +196,9 @@ pub fn args_scan() -> ScanArgs {
     }
 }
 
-
 fn is_json_string(json_str: &str) -> bool {
     match serde_json::from_str::<Value>(json_str) {
         Ok(_) => true,
         Err(_) => false,
     }
 }
-

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ use lua::{
     model::LuaOptions,
     parsing::files::filename_to_string,
     run::LuaLoader,
-    threads::runner::{iter_futures, LAST_HOST_SCAN_ID},
+    threads::runner::{iter_futures, LAST_HOST_SCAN_ID, LAST_HTTP_SCAN_ID},
 };
 use mlua::ExternalError;
 pub use model::{Lotus, RequestOpts, ScanTypes};
@@ -52,7 +52,13 @@ impl Lotus {
             return;
         }
         let resume_value: usize;
+        log::debug!("START SCAN : {:?} {:?}", scan_type, target_data);
         let loaded_scripts = match scan_type {
+            ScanTypes::FULL_HTTP => {
+                resume_value = *LAST_HTTP_SCAN_ID.lock().unwrap();
+                log::debug!("SCAN {:?}", loaded_scripts);
+                valid_scripts(loaded_scripts, 0)
+            }
             ScanTypes::HOSTS => {
                 resume_value = *LAST_HOST_SCAN_ID.lock().unwrap();
                 valid_scripts(loaded_scripts, 1)

--- a/src/lua/parsing/req.rs
+++ b/src/lua/parsing/req.rs
@@ -2,7 +2,10 @@ use crate::lua::network::http::HttpResponse;
 use mlua::Lua;
 use std::borrow::Cow;
 
-pub fn show_response<'lua>(_: &'lua Lua,res: HttpResponse) -> Result<Cow<'static, str>, mlua::Error> {
+pub fn show_response<'lua>(
+    _: &'lua Lua,
+    res: HttpResponse,
+) -> Result<Cow<'static, str>, mlua::Error> {
     let headers_str = {
         let mut headers_str = String::new();
         res.headers.iter().for_each(|(headername, headervalue)| {

--- a/src/lua/run.rs
+++ b/src/lua/run.rs
@@ -89,12 +89,13 @@ impl LuaLoader {
 
         match lua_opts.target_type {
             ScanTypes::FULL_HTTP => {
-                let request_value: FullRequest = serde_json::from_value(lua_opts.target_url.unwrap().clone()).unwrap();
-                self.set_lua(None,Some(request_value), &lua)
+                let request_value: FullRequest =
+                    serde_json::from_value(lua_opts.target_url.unwrap().clone()).unwrap();
+                self.set_lua(None, Some(request_value), &lua)
             }
             ScanTypes::HOSTS => {
                 // for HOSTS, set TARGET_HOST global
-                self.set_lua(None,None, &lua);
+                self.set_lua(None, None, &lua);
                 lua.globals()
                     .set(
                         "INPUT_DATA",
@@ -122,7 +123,7 @@ impl LuaLoader {
                 lua.globals()
                     .set("INPUT_DATA", lua.to_value(&serde_value).unwrap())
                     .unwrap();
-                self.set_lua(None, None,&lua);
+                self.set_lua(None, None, &lua);
             }
         };
 

--- a/src/lua/run.rs
+++ b/src/lua/run.rs
@@ -1,3 +1,4 @@
+use crate::cli::input::parse_requests::FullRequest;
 use crate::lua::runtime::{encode_ext::EncodeEXT, http_ext::HTTPEXT, utils_ext::UtilsEXT};
 use crate::{
     cli::bar::BAR,
@@ -32,10 +33,10 @@ impl LuaLoader {
 
     /// Set Lua Functions for http and matching
     ///
-    fn set_lua(&self, target_url: Option<&str>, lua: &Lua) {
+    fn set_lua(&self, target_url: Option<&str>, fullhttp_msg: Option<FullRequest>, lua: &Lua) {
         // Adding Lotus Lua Function
         let lua_eng = LuaRunTime { lua };
-        lua_eng.add_httpfuncs(target_url);
+        lua_eng.add_httpfuncs(target_url, fullhttp_msg);
         lua_eng.add_encode_function();
         lua_eng.add_printfunc();
         lua_eng.add_matchingfunc();
@@ -87,9 +88,13 @@ impl LuaLoader {
             .unwrap();
 
         match lua_opts.target_type {
+            ScanTypes::FULL_HTTP => {
+                let request_value: FullRequest = serde_json::from_value(lua_opts.target_url.unwrap().clone()).unwrap();
+                self.set_lua(None,Some(request_value), &lua)
+            }
             ScanTypes::HOSTS => {
                 // for HOSTS, set TARGET_HOST global
-                self.set_lua(None, &lua);
+                self.set_lua(None,None, &lua);
                 lua.globals()
                     .set(
                         "INPUT_DATA",
@@ -101,12 +106,14 @@ impl LuaLoader {
                 // for all other target types, set target URL
                 self.set_lua(
                     Some(&lua_opts.target_url.unwrap().as_str().unwrap().to_string()),
+                    None,
                     &lua,
                 );
             }
             ScanTypes::PATHS => {
                 self.set_lua(
                     Some(&lua_opts.target_url.unwrap().as_str().unwrap().to_string()),
+                    None,
                     &lua,
                 );
             }
@@ -115,7 +122,7 @@ impl LuaLoader {
                 lua.globals()
                     .set("INPUT_DATA", lua.to_value(&serde_value).unwrap())
                     .unwrap();
-                self.set_lua(None, &lua);
+                self.set_lua(None, None,&lua);
             }
         };
 

--- a/src/lua/runtime/http_ext.rs
+++ b/src/lua/runtime/http_ext.rs
@@ -1,4 +1,5 @@
 use crate::{
+    cli::input::parse_requests::FullRequest,
     lua::{
         model::LuaRunTime,
         output::report::AllReports,
@@ -14,20 +15,21 @@ use tokio::time::sleep;
 use url::Url;
 
 pub trait HTTPEXT {
-    fn add_httpfuncs(&self, target_url: Option<&str>);
+    fn add_httpfuncs(&self, target_url: Option<&str>, full_httpmsg: Option<FullRequest>);
 }
 
 impl HTTPEXT for LuaRunTime<'_> {
-    fn add_httpfuncs(&self, target_url: Option<&str>) {
+    fn add_httpfuncs(&self, target_url: Option<&str>, full_httpmsg: Option<FullRequest>) {
         self.lua
             .globals()
             .set(
                 "show_response",
-                self.lua
-                    .create_function(show_response)
-                    .unwrap(),
+                self.lua.create_function(show_response).unwrap(),
             )
             .unwrap();
+        if let Some(full_httpmsg) = full_httpmsg {
+            self.lua.globals().set("full_req", full_httpmsg).unwrap();
+        }
         let headers_converter = self
             .lua
             .create_function(|_, headers_txt: String| {

--- a/src/lua/runtime/utils_ext.rs
+++ b/src/lua/runtime/utils_ext.rs
@@ -6,10 +6,9 @@ use crate::{
     },
     BAR,
 };
-use std::sync::{Arc, Mutex};
-use std::path::Path;
 use log::{debug, error, info, warn};
-
+use std::path::Path;
+use std::sync::{Arc, Mutex};
 
 pub trait UtilsEXT {
     fn add_threadsfunc(&self);

--- a/src/lua/threads/runner.rs
+++ b/src/lua/threads/runner.rs
@@ -35,11 +35,13 @@ fn generate_resume() -> Result<(), std::io::Error> {
         .create(true)
         .open("resume.cfg")?;
 
+    let http_scan_id = LAST_HTTP_SCAN_ID.lock().unwrap();
     let url_scan_id = LAST_URL_SCAN_ID.lock().unwrap();
     let host_scan_id = LAST_HOST_SCAN_ID.lock().unwrap();
     let path_scan_id = LAST_PATH_SCAN_ID.lock().unwrap();
     let custom_scan_id = LAST_CUSTOM_SCAN_ID.lock().unwrap();
 
+    file.write_all(format!("HTTP_SCAN_ID={}\n", *http_scan_id).as_bytes())?;
     file.write_all(format!("URL_SCAN_ID={}\n", *url_scan_id).as_bytes())?;
     file.write_all(format!("HOST_SCAN_ID={}\n", *host_scan_id).as_bytes())?;
     file.write_all(format!("PATH_SCAN_ID={}\n", *path_scan_id).as_bytes())?;
@@ -50,6 +52,7 @@ fn generate_resume() -> Result<(), std::io::Error> {
 
 fn update_index_id(scan_type: Arc<ScanTypes>, index_id: usize) {
     match *scan_type {
+        ScanTypes::FULL_HTTP => *LAST_HTTP_SCAN_ID.lock().unwrap() = index_id,
         ScanTypes::URLS => *LAST_URL_SCAN_ID.lock().unwrap() = index_id,
         ScanTypes::HOSTS => *LAST_HOST_SCAN_ID.lock().unwrap() = index_id,
         ScanTypes::PATHS => *LAST_PATH_SCAN_ID.lock().unwrap() = index_id,

--- a/src/lua/threads/runner.rs
+++ b/src/lua/threads/runner.rs
@@ -12,6 +12,7 @@ use crate::cli::bar::{show_msg, MessageLevel};
 use crate::ScanTypes;
 
 lazy_static! {
+    pub static ref LAST_HTTP_SCAN_ID: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
     pub static ref LAST_URL_SCAN_ID: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
     pub static ref LAST_HOST_SCAN_ID: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));
     pub static ref LAST_PATH_SCAN_ID: Arc<Mutex<usize>> = Arc::new(Mutex::new(0));

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,10 @@ async fn run_scan() -> Result<(), std::io::Error> {
     );
 
     show_msg(
-        &format!("Number of HTTP MSGS: {}", opts.target_data.parse_requests.len()),
+        &format!(
+            "Number of HTTP MSGS: {}",
+            opts.target_data.parse_requests.len()
+        ),
         MessageLevel::Info,
     );
     show_msg(

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,9 @@
 
 use lotus::{
     cli::{
-        input::load_scripts::get_scripts,
         args::Opts,
         bar::{create_progress, show_msg, MessageLevel, BAR},
+        input::load_scripts::get_scripts,
         startup::{new::new_args, scan::scan::args_scan},
     },
     lua::{
@@ -55,6 +55,10 @@ async fn run_scan() -> Result<(), std::io::Error> {
     );
 
     show_msg(
+        &format!("Number of HTTP MSGS: {}", opts.target_data.parse_requests.len()),
+        MessageLevel::Info,
+    );
+    show_msg(
         &format!("Number of paths: {}", opts.target_data.paths.len()),
         MessageLevel::Info,
     );
@@ -79,6 +83,14 @@ async fn run_scan() -> Result<(), std::io::Error> {
         *VERBOSE_MODE.lock().unwrap() = opts.verbose;
     }
     let scan_futures = vec![
+        opts.lotus_obj.start(
+            opts.target_data.parse_requests,
+            scripts.clone(),
+            opts.req_opts.clone(),
+            ScanTypes::FULL_HTTP,
+            opts.exit_after,
+            fuzz_workers,
+        ),
         opts.lotus_obj.start(
             convert_serde_value(opts.target_data.paths),
             scripts.clone(),

--- a/src/model.rs
+++ b/src/model.rs
@@ -18,8 +18,9 @@ pub struct RequestOpts {
 }
 
 /// Scanning type For `SCAN_TYPE` in lua scripts
-#[derive(Clone, Copy)]
+#[derive(Debug,Clone, Copy)]
 pub enum ScanTypes {
+    #[allow(non_camel_case_types)]
     FULL_HTTP,
     /// HOSTS Scanning under ID number 1
     HOSTS,

--- a/src/model.rs
+++ b/src/model.rs
@@ -18,7 +18,7 @@ pub struct RequestOpts {
 }
 
 /// Scanning type For `SCAN_TYPE` in lua scripts
-#[derive(Debug,Clone, Copy)]
+#[derive(Debug, Clone, Copy)]
 pub enum ScanTypes {
     #[allow(non_camel_case_types)]
     FULL_HTTP,

--- a/src/model.rs
+++ b/src/model.rs
@@ -20,6 +20,7 @@ pub struct RequestOpts {
 /// Scanning type For `SCAN_TYPE` in lua scripts
 #[derive(Clone, Copy)]
 pub enum ScanTypes {
+    FULL_HTTP,
     /// HOSTS Scanning under ID number 1
     HOSTS,
     /// URLS Scanning under ID number 2


### PR DESCRIPTION
To scan full requests under the SCAN_ID number 0 in Lotus, users can employ a single function to inject the payload. By utilizing CLI options, they can specify the specific portion of the request they wish to scan.
